### PR TITLE
Fix: Resolve Rust compilation errors identified by clippy

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -616,7 +616,7 @@ impl Client {
         let mut summary_futures = Vec::new();
         for entry in glob(pattern)? {
             let path = entry?.to_string_lossy().to_string();
-            summary_futures.push(self.get_content_summary(&path));
+            summary_futures.push(self.get_content_summary(path.clone()));
         }
 
         let summaries = try_join_all(summary_futures).await?;

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -64,7 +64,7 @@ impl From<glob::GlobError> for HdfsError {
         // glob::GlobError typically wraps an std::io::Error.
         // We can choose to store its string representation or map it to HdfsError::IOError directly if preferred.
         // For this task, let's store its string representation in HdfsError::Glob for clarity.
-        HdfsError::Glob(format!("Glob error: {}", err.into_io_error().to_string()))
+        HdfsError::Glob(format!("Glob error: {}", err.into_error().to_string()))
     }
 }
 


### PR DESCRIPTION
This commit addresses two specific compilation errors:

1.  `error[E0597]: \`path\` does not live long enough`
    - Occurred in `rust/src/client.rs` in the `get_content_summary_glob` function.
    - The `path` variable created within a loop was dropped while still borrowed by futures stored for later execution.
    - Fixed by cloning `path` (`path.clone()`) when calling `self.get_content_summary`, ensuring the data lives as long as the futures that require it.

2.  `error[E0599]: no method named \`into_io_error\` found for struct \`glob::GlobError\``
    - Occurred in `rust/src/error.rs` when converting a `glob::GlobError` to `HdfsError`.
    - The method `into_io_error()` does not exist for `glob::GlobError`.
    - Fixed by changing the call to `err.into_error().to_string()`, as suggested by the compiler and confirmed by the `glob` crate API, to correctly retrieve the underlying `io::Error`.

These changes should resolve the clippy build failures related to these errors.